### PR TITLE
Add role color skipping for slash bots that are not in bot scope

### DIFF
--- a/src/yagpdb.xyz/custom-commands/link-preview.go.tmpl
+++ b/src/yagpdb.xyz/custom-commands/link-preview.go.tmpl
@@ -13,11 +13,14 @@
 
     {{$col := 16777215}}{{/* default color is white */}}
     {{$p := 0}}
-    {{$r := (getMember $msg.Author).Roles}}
-    {{range .Guild.Roles}}
-      {{if and (in $r .ID) (.Color) (lt $p .Position)}}
-        {{$p = .Position}}
-        {{$col = .Color}}
+    {{$m := getMember $msg.Author.ID}}
+    {{ if $m}}
+      {{$r := $m.Roles}}
+      {{range .Guild.Roles}}
+        {{if and (in $r .ID) (.Color) (lt $p .Position)}}
+          {{$p = .Position}}
+          {{$col = .Color}}
+        {{end}}
       {{end}}
     {{end}}
 


### PR DESCRIPTION
Slash bots that only have permissions to add slash commands and not in bot scope, won't have a member ID. In such cases accessing its `.Roles` would crash the code.

This PR handles this edge case