### PR TITLE
fixes: trigger message not deleted when convo moved to read-only channel

### DIFF
--- a/src/yagpdb.xyz/custom-commands/channel-move.go.tmpl
+++ b/src/yagpdb.xyz/custom-commands/channel-move.go.tmpl
@@ -66,6 +66,8 @@
     {{ if not $authorColor }}
         {{ $authorColor = $embedColor }}
     {{ end }}
+    
+    {{ deleteTrigger $deleteTriggerDelay }}
 
     {{ editMessage nil $hereMsgID (complexMessageEdit
         "content" ""
@@ -86,5 +88,4 @@
         )
     ) }}
 
-    {{ deleteTrigger $deleteTriggerDelay }}
 {{ end }}


### PR DESCRIPTION
This is because the command execution is halted halfway due to missing write permissions for `@everyone`